### PR TITLE
Resolve symlinks

### DIFF
--- a/sn
+++ b/sn
@@ -1,5 +1,7 @@
-#!/bin/bash
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+#!/usr/bin/env bash
+
+RESOLVED_SOURCE=$(perl -MCwd -le 'print Cwd::abs_path(shift)' "${BASH_SOURCE[0]}")
+DIR=$( cd "$( dirname $RESOLVED_SOURCE )" && pwd )
 
 envprefix=SN_OPTION_
 snflagprefix=SN_NIX_SHELL_


### PR DESCRIPTION
The sn script as is can't figure out it's own directory if a symlink to the script is on the path.

You get...
```
nix-setup (master)$ln -s ~/dev/lp/nix-setup/sn ~/bin/
nix-setup (master)$sn scala
Entering Nix shell for shellutil
error: getting status of '/Users/andy/bin/shell.nix': No such file or directory
Leaving Nix shell for shellutil
```

This change follows symlinks if present. From https://stackoverflow.com/questions/7665/how-to-resolve-symbolic-links-in-a-shell-script