### PR TITLE
jdk17, kubectl + base image update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .bloop
 .metals
 .terraform
+.vscode/
 *.pem
 app.*.log.gz
 *.tfstate*

--- a/aws.nix
+++ b/aws.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };

--- a/gcp.nix
+++ b/gcp.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };
@@ -22,6 +22,7 @@ in
       gcptools
       pkgs.kubernetes-helm
       pkgs.kubectl
+      pkgs.kubectx
     ];
 
     shellHook = ''

--- a/scala.nix
+++ b/scala.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
       overlays = [ (
@@ -18,7 +18,7 @@ let
       ) ];
     };
 
-  use-jdk = pkgs.jdk16;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
+  use-jdk = pkgs.jdk17;   # callPackage jdk/shared-jdk.nix { inherit jdk-name; inherit jdk-sha; };
 in
   pkgs.stdenv.mkDerivation rec {
     name = "Scala";

--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,11 @@ let
     import (
       builtins.fetchTarball {
         # Descriptive name to make the store path easier to identify
-        name = "nixos-unstable-2021-09-31";
-        # Commit hash for nixos-unstable as of 2021-09-31 - get from head (git log)
-        url = https://github.com/nixos/nixpkgs/archive/39ab62f8f644c1a076cdba8de12baf15142cfe59.tar.gz;
+        name = "nixos-unstable-2022-01-03";
+        # Commit hash for nixos-unstable as of 2022-01-03 - get from head (git log)
+        url = https://github.com/nixos/nixpkgs/archive/59bfda72480496f32787cec8c557182738b1bd3f.tar.gz;
         # Hash obtained using `nix-prefetch-url --unpack <url>`
-        sha256 = "1n9gf65cvd0i14ricnz55j1cr5mwvajg6678342fm738xid9fv08";
+        sha256 = "18akd1chfvniq1q774rigfxgmxwi0wyjljpa1j9ls59szpzr316d";
       }
     ) {
     };


### PR DESCRIPTION
Added kubectx for gcp
Updated to jdk17 for scala
Bumped nixos snapshot version to 2022-01-03 for aws, gcp, scala and shell

Tested locally on macOS Monterey